### PR TITLE
add hunter_joint_state_publisher

### DIFF
--- a/hunter_base/CMakeLists.txt
+++ b/hunter_base/CMakeLists.txt
@@ -50,14 +50,19 @@ set(DEPENDENCIES
 )
 
 
-add_executable(hunter_base_node 
+add_executable(hunter_base_node
     src/hunter_base_ros.cpp
     src/hunter_base_node.cpp
     src/bicycle_model.cpp)
 target_link_libraries(hunter_base_node ugv_sdk ${dependencies} ascent)
 ament_target_dependencies(hunter_base_node rclcpp tf2 tf2_ros std_msgs nav_msgs sensor_msgs hunter_msgs tf2_geometry_msgs ${dependencies})
 
-install(TARGETS hunter_base_node
+add_executable(hunter_joint_state_publisher
+    src/hunter_joint_state_publisher.cpp)
+ament_target_dependencies(hunter_joint_state_publisher
+    rclcpp sensor_msgs hunter_msgs)
+
+install(TARGETS hunter_base_node hunter_joint_state_publisher
   DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY launch

--- a/hunter_base/include/hunter_base/hunter_params.hpp
+++ b/hunter_base/include/hunter_base/hunter_params.hpp
@@ -37,7 +37,7 @@ struct HunterSEParams {
   static constexpr double wheelbase =
       0.55;  // in meter (front & rear wheel distance)
   static constexpr double wheel_radius = 0.1375;             // in meter
-  static constexpr double transmission_reduction_rate = 30;  // 1:30
+  static constexpr double transmission_reduction_rate = 4;  // 1:4
 
   static constexpr double max_steer_angle =
       0.283;  // in rad, 0.75 for inner wheel

--- a/hunter_base/include/hunter_base/joint_state_publisher.hpp
+++ b/hunter_base/include/hunter_base/joint_state_publisher.hpp
@@ -1,0 +1,71 @@
+/*
+ * joint_state_publisher.hpp
+ *
+ * Description:
+ *   Publishes sensor_msgs/JointState for the Hunter chassis by subscribing
+ *   to /hunter_status. Computes all four wheel angular velocities (rad/s)
+ *   and the front-left / front-right steering angles (rad) via Ackermann
+ *   split.
+ *
+ *   Hunter SE actuator id mapping (from hardware):
+ *     1: front steering motor (not a wheel velocity)
+ *     2: rear right wheel motor
+ *     3: rear left  wheel motor
+ *   Front wheels are not driven, so their angular velocities are estimated
+ *   from the chassis linear velocity.
+ */
+
+#ifndef HUNTER_BASE_JOINT_STATE_PUBLISHER_HPP
+#define HUNTER_BASE_JOINT_STATE_PUBLISHER_HPP
+
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+
+#include "hunter_msgs/msg/hunter_status.hpp"
+
+namespace westonrobot {
+
+class JointStatePublisher : public rclcpp::Node {
+ public:
+  JointStatePublisher();
+
+ private:
+  // ~0.29 deg dead-band for steering split
+  static constexpr double kSteerTol = 0.005;
+
+  void OnStatus(const hunter_msgs::msg::HunterStatus::SharedPtr msg);
+
+  // Split a central (bicycle-model) steering angle into per-wheel angles
+  // using Ackermann geometry. Sign convention: positive = left turn.
+  void SplitSteerAngle(double phi_c, double &phi_l, double &phi_r) const;
+
+  double MotorRpmToWheelOmega(double rpm) const;
+
+  double wheelbase_ = 0.0;
+  double track_ = 0.0;
+  double wheel_radius_ = 0.0;
+  double reduction_ = 1.0;
+
+  // accumulated wheel rotations (rad), integrated from omega over time
+  double pos_fl_ = 0.0;
+  double pos_fr_ = 0.0;
+  double pos_bl_ = 0.0;
+  double pos_br_ = 0.0;
+  rclcpp::Time last_stamp_{0, 0, RCL_ROS_TIME};
+
+  std::string fl_wheel_joint_;
+  std::string fr_wheel_joint_;
+  std::string bl_wheel_joint_;
+  std::string br_wheel_joint_;
+  std::string l_steer_joint_;
+  std::string r_steer_joint_;
+
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr pub_;
+  rclcpp::Subscription<hunter_msgs::msg::HunterStatus>::SharedPtr sub_;
+};
+
+}  // namespace westonrobot
+
+#endif  // HUNTER_BASE_JOINT_STATE_PUBLISHER_HPP

--- a/hunter_base/src/hunter_joint_state_publisher.cpp
+++ b/hunter_base/src/hunter_joint_state_publisher.cpp
@@ -1,0 +1,179 @@
+/*
+ * joint_state_publisher_node.cpp
+ */
+
+#include "hunter_base/joint_state_publisher.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "hunter_base/hunter_params.hpp"
+
+namespace westonrobot {
+
+JointStatePublisher::JointStatePublisher()
+    : rclcpp::Node("joint_state_publisher") {
+  declare_parameter<std::string>("robot_model", "hunter_se");
+  declare_parameter<std::string>("status_topic", "/hunter_status");
+  declare_parameter<std::string>("joint_states_topic", "/joint_states");
+  declare_parameter<std::string>("fl_wheel_joint", "fl_wheel_joint");
+  declare_parameter<std::string>("fr_wheel_joint", "fr_wheel_joint");
+  declare_parameter<std::string>("bl_wheel_joint", "bl_wheel_joint");
+  declare_parameter<std::string>("br_wheel_joint", "br_wheel_joint");
+  declare_parameter<std::string>("l_steer_joint", "l_steer_joint");
+  declare_parameter<std::string>("r_steer_joint", "r_steer_joint");
+
+  std::string robot_model;
+  get_parameter("robot_model", robot_model);
+  if (robot_model == "hunter_se") {
+    wheelbase_ = HunterSEParams::wheelbase;
+    track_ = HunterSEParams::track;
+    wheel_radius_ = HunterSEParams::wheel_radius;
+    reduction_ = HunterSEParams::transmission_reduction_rate;
+  } else if (robot_model == "hunter1") {
+    wheelbase_ = HunterV1Params::wheelbase;
+    track_ = HunterV1Params::track;
+    wheel_radius_ = HunterV1Params::wheel_radius;
+    reduction_ = HunterV1Params::transmission_reduction_rate;
+  } else {
+    wheelbase_ = HunterV2Params::wheelbase;
+    track_ = HunterV2Params::track;
+    wheel_radius_ = HunterV2Params::wheel_radius;
+    reduction_ = HunterV2Params::transmission_reduction_rate;
+  }
+
+  get_parameter("fl_wheel_joint", fl_wheel_joint_);
+  get_parameter("fr_wheel_joint", fr_wheel_joint_);
+  get_parameter("bl_wheel_joint", bl_wheel_joint_);
+  get_parameter("br_wheel_joint", br_wheel_joint_);
+  get_parameter("l_steer_joint", l_steer_joint_);
+  get_parameter("r_steer_joint", r_steer_joint_);
+
+  std::string status_topic;
+  std::string joint_states_topic;
+  get_parameter("status_topic", status_topic);
+  get_parameter("joint_states_topic", joint_states_topic);
+
+  pub_ =
+      create_publisher<sensor_msgs::msg::JointState>(joint_states_topic, 10);
+  sub_ = create_subscription<hunter_msgs::msg::HunterStatus>(
+      status_topic, 10,
+      std::bind(&JointStatePublisher::OnStatus, this, std::placeholders::_1));
+
+  RCLCPP_INFO(get_logger(),
+              "joint_state_publisher started: model=%s wheelbase=%.3f "
+              "track=%.3f wheel_radius=%.4f reduction=%.1f",
+              robot_model.c_str(), wheelbase_, track_, wheel_radius_,
+              reduction_);
+}
+
+void JointStatePublisher::SplitSteerAngle(double phi_c, double &phi_l,
+                                          double &phi_r) const {
+  phi_l = 0.0;
+  phi_r = 0.0;
+  if (phi_c > kSteerTol) {
+    // left turn: left wheel is inner (larger angle)
+    const double s = std::sin(phi_c);
+    const double c = std::cos(phi_c);
+    phi_l = std::atan2(2.0 * wheelbase_ * s,
+                       2.0 * wheelbase_ * c - track_ * s);
+    phi_r = std::atan2(2.0 * wheelbase_ * s,
+                       2.0 * wheelbase_ * c + track_ * s);
+  } else if (phi_c < -kSteerTol) {
+    // right turn: right wheel is inner (larger magnitude, negative)
+    const double p = -phi_c;
+    const double s = std::sin(p);
+    const double c = std::cos(p);
+    phi_r = -std::atan2(2.0 * wheelbase_ * s,
+                        2.0 * wheelbase_ * c - track_ * s);
+    phi_l = -std::atan2(2.0 * wheelbase_ * s,
+                        2.0 * wheelbase_ * c + track_ * s);
+  }
+}
+
+double JointStatePublisher::MotorRpmToWheelOmega(double rpm) const {
+  return rpm * 2.0 * M_PI / 60.0 / reduction_;
+}
+
+void JointStatePublisher::OnStatus(
+    const hunter_msgs::msg::HunterStatus::SharedPtr msg) {
+  double omega_br = 0.0;
+  double omega_bl = 0.0;
+  bool has_br = false;
+  bool has_bl = false;
+  for (const auto &act : msg->actuator_states) {
+    const double omega = MotorRpmToWheelOmega(static_cast<double>(act.rpm));
+    switch (act.motor_id) {
+      case 2:  // rear right wheel
+        omega_br = omega;
+        has_br = true;
+        break;
+      case 3:  // rear left wheel
+        omega_bl = omega;
+        has_bl = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Fallback to chassis linear velocity if rear-wheel telemetry missing.
+  const double omega_chassis = msg->linear_velocity / wheel_radius_;
+  if (!has_br) omega_br = omega_chassis;
+  if (!has_bl) omega_bl = omega_chassis;
+
+  // Front wheels are not driven; estimate from Ackermann kinematics.
+  // Each front wheel rolls at |omega_z| * d_i, where d_i is the distance
+  // from the wheel center to the Instantaneous Center of Rotation (ICR).
+  // ICR sits on the rear axle line at y = R = wheelbase / tan(phi_c).
+  double omega_fl = omega_chassis;
+  double omega_fr = omega_chassis;
+  const double v = msg->linear_velocity;
+  const double phi_c = msg->steering_angle;
+  if (std::fabs(phi_c) >= kSteerTol) {
+    const double R = wheelbase_ / std::tan(phi_c);   // signed turn radius
+    const double d_fl = std::hypot(wheelbase_, R - track_ / 2.0);
+    const double d_fr = std::hypot(wheelbase_, R + track_ / 2.0);
+    const double sign_v = (v >= 0.0) ? 1.0 : -1.0;
+    const double omega_z_abs = std::fabs(v / R);
+    omega_fl = sign_v * omega_z_abs * d_fl / wheel_radius_;
+    omega_fr = sign_v * omega_z_abs * d_fr / wheel_radius_;
+  }
+
+  // status.steering_angle is already the central (bicycle) angle.
+  double phi_l = 0.0;
+  double phi_r = 0.0;
+  SplitSteerAngle(msg->steering_angle, phi_l, phi_r);
+
+  // Integrate wheel angular velocities to get wheel angles for TF.
+  // continuous joints in URDF use `position` (not velocity) for transform.
+  const rclcpp::Time stamp(msg->header.stamp);
+  double dt = 0.0;
+  if (last_stamp_.nanoseconds() != 0) {
+    dt = (stamp - last_stamp_).seconds();
+    if (dt < 0.0 || dt > 1.0) dt = 0.0;  // skip on clock jump
+  }
+  last_stamp_ = stamp;
+
+  pos_fl_ = std::remainder(pos_fl_ + omega_fl * dt, 2.0 * M_PI);
+  pos_fr_ = std::remainder(pos_fr_ + omega_fr * dt, 2.0 * M_PI);
+  pos_bl_ = std::remainder(pos_bl_ + omega_bl * dt, 2.0 * M_PI);
+  pos_br_ = std::remainder(pos_br_ + omega_br * dt, 2.0 * M_PI);
+
+  sensor_msgs::msg::JointState js;
+  js.header.stamp = stamp;
+  js.name = {fl_wheel_joint_, fr_wheel_joint_, bl_wheel_joint_,
+             br_wheel_joint_, l_steer_joint_,  r_steer_joint_};
+  js.position = {pos_fl_, pos_fr_, pos_bl_, pos_br_, phi_l, phi_r};
+  js.velocity = {omega_fl, omega_fr, omega_bl, omega_br, 0.0, 0.0};
+  pub_->publish(js);
+}
+
+}  // namespace westonrobot
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<westonrobot::JointStatePublisher>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
joint state publisherを実装。

<img width="640" height="451" alt="simplescreenrecorder-2026-05-22_21 04 59" src="https://github.com/user-attachments/assets/fc4a2108-bbd6-44c9-8cdf-4649c50d8fbd" />

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #5 

<!-- 変更の詳細 -->
## Detail

`hunter_base` パッケージに `/joint_states` を発行する新規ノード `hunter_joint_state_publisher` (ROS ノード名: `joint_state_publisher`) を追加。

- `/hunter_status` (`hunter_msgs/HunterStatus`) を購読し、以下を `sensor_msgs/JointState` に変換して `/joint_states` に発行
  - **車輪角速度** (`velocity`, rad/s) × 4輪
  - **車輪累積回転角** (`position`, rad) × 4輪 — `omega * dt` を時間積分（`continuous` joint で TF を駆動するため必要）
  - **前輪ステアリング角度** (`position`, rad) × 左右
- 後輪は `actuator_states[].motor_id` の `2` (右後輪) と `3` (左後輪) の RPM をモータ減速比で割って車輪角速度に変換
- 前輪は非駆動のためアッカーマン旋回キネマティクスから推定（ICR と各前輪との距離比で左右別に算出。直進時は両輪同じ）
- 前輪ステアリングは `status.steering_angle`（central / バイシクル角）をアッカーマン逆変換で左右輪に分割
- パラメータで対応モデル (`hunter_se` / `hunter1` / `hunter2`) と各ジョイント名 (`fl_wheel_joint`, `fr_wheel_joint`, `bl_wheel_joint`, `br_wheel_joint`, `l_steer_joint`, `r_steer_joint`) を設定可能

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

- `hunter_base` パッケージに新しい executable `hunter_joint_state_publisher` が追加されるのみ。
- 既存の `hunter_base_node` および他のソース・launch ファイルには変更なし。
- URDF 側に対応するジョイント名 (`*_wheel_joint`, `*_steer_joint`) が定義されていれば、`robot_state_publisher` と組み合わせて TF が自動で更新される。
- 後方互換性への影響なし。

<!-- どのような動作検証を行ったか -->
## Test
* [x] ビルドが通った
* [ ] gazebo環境で動作した
* [x] 実機環境で動作した

## Attention

- **Hunter SE 実機の `motor_id` マッピングは `HunterStatus.msg` の定数と異なる**。
  - メッセージ定義: `FR=0`, `FL=1`, `RR=2`, `RL=3`
  - Hunter SE 実機: `1=front steering`, `2=rear right wheel`, `3=rear left wheel`
  - 本ノードは実機マッピングに従い、生の数値 `2`, `3` で分岐している。V1/V2 で挙動が異なる可能性あり（要検証）。
- **`HunterSEParams::transmission_reduction_rate = 4`**（V1/V2 は `30`、そもそも正しいかどうか怪しい）。デフォルト `robot_model` は `hunter_se`。
- **前輪角速度は推定値**。Hunter SE は後輪駆動のため実測 RPM は取得できない。アッカーマン旋回キネマティクスで ICR（旋回中心）からの距離比に基づき左右別個に計算する（直進時は両輪 `linear_velocity / wheel_radius`、旋回時は内側輪 < 外側輪 で速度差が出る）。
- **車輪の回転方向は URDF の `<axis>` 設計に依存**。実機モーターの RPM 符号と URDF の axis が整合している前提（特に左右で axis を逆にしている場合は注意）。
- 時刻が逆行 / 1 秒以上のジャンプが発生した場合は当該フレームの position 積分をスキップ（クロックジャンプ時の position 暴走防止）。
