### PR TITLE
Publish battery state as sensor_msgs/BatteryState

### DIFF
--- a/hunter_base/include/hunter_base/hunter_messenger.hpp
+++ b/hunter_base/include/hunter_base/hunter_messenger.hpp
@@ -290,14 +290,38 @@ class HunterMessenger {
     battery_msg.charge = nan;
     battery_msg.capacity = nan;
     battery_msg.design_capacity = nan;
-    battery_msg.power_supply_status =
-        sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_UNKNOWN;
+    // Estimate the charging state from the BMS current.
+    // AgileX current sign convention (confirmed on the actual robot):
+    //   positive -> charging, negative -> discharging.
+    using BatteryStateMsg = sensor_msgs::msg::BatteryState;
+    constexpr float current_deadband = 0.5F;  // [A] to avoid status flicker
+    if (bms.voltage <= 0.0F) {
+      // BMS basic frame not received (may be unavailable on the Hunter SE).
+      battery_msg.power_supply_status =
+          BatteryStateMsg::POWER_SUPPLY_STATUS_UNKNOWN;
+    } else if (bms.current < -current_deadband) {
+      // Negative current: discharging (e.g. driving).
+      battery_msg.power_supply_status =
+          BatteryStateMsg::POWER_SUPPLY_STATUS_DISCHARGING;
+    } else if (bms.current > current_deadband) {
+      // Positive current: charging. Report FULL once SOC reaches 90%.
+      battery_msg.power_supply_status =
+          (bms.battery_soc >= 90)
+              ? BatteryStateMsg::POWER_SUPPLY_STATUS_FULL
+              : BatteryStateMsg::POWER_SUPPLY_STATUS_CHARGING;
+    } else if (bms.battery_soc >= 90) {
+      // Idle current and SOC full -> fully charged.
+      battery_msg.power_supply_status =
+          BatteryStateMsg::POWER_SUPPLY_STATUS_FULL;
+    } else {
+      battery_msg.power_supply_status =
+          BatteryStateMsg::POWER_SUPPLY_STATUS_NOT_CHARGING;
+    }
     battery_msg.power_supply_health =
         sensor_msgs::msg::BatteryState::POWER_SUPPLY_HEALTH_UNKNOWN;
     battery_msg.power_supply_technology =
         sensor_msgs::msg::BatteryState::POWER_SUPPLY_TECHNOLOGY_LION;
     battery_msg.present = true;
-    
     battery_state_pub_->publish(battery_msg);
   }
 

--- a/hunter_base/include/hunter_base/hunter_messenger.hpp
+++ b/hunter_base/include/hunter_base/hunter_messenger.hpp
@@ -13,10 +13,12 @@
 #include <string>
 #include <mutex>
 #include <memory>
+#include <limits>
 
 #include <rclcpp/rclcpp.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <sensor_msgs/msg/battery_state.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -85,6 +87,9 @@ class HunterMessenger {
         node_->create_publisher<nav_msgs::msg::Odometry>(odom_topic_name_, 50);
     status_pub_ = node_->create_publisher<hunter_msgs::msg::HunterStatus>(
         "/hunter_status", 10);
+    battery_state_pub_ =
+        node_->create_publisher<sensor_msgs::msg::BatteryState>(
+            "/battery_state", 10);
 
     // cmd subscriber
     motion_cmd_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(
@@ -151,6 +156,9 @@ class HunterMessenger {
 
     status_pub_->publish(status_msg);
 
+    // publish battery state
+    PublishBatteryStateToROS(state.system_state);
+
     // publish odometry and tf
     PublishOdometryToROS(state.motion_state, dt);
 
@@ -177,6 +185,8 @@ class HunterMessenger {
 
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
   rclcpp::Publisher<hunter_msgs::msg::HunterStatus>::SharedPtr status_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr
+      battery_state_pub_;
 
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr motion_cmd_sub_;
   
@@ -261,6 +271,34 @@ class HunterMessenger {
     tf2::Quaternion q;
     q.setRPY(0, 0, yaw);
     return tf2::toMsg(q);
+  }
+
+  void PublishBatteryStateToROS(const SystemStateMessage &system_state) {
+    // BMS basic frame may be absent on the Hunter SE (0 if not reported).
+    auto sensor_state = hunter_->GetCommonSensorState();
+    const auto &bms = sensor_state.bms_basic_state;
+
+    sensor_msgs::msg::BatteryState battery_msg;
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    battery_msg.header.stamp = current_time_;
+    // Voltage is taken from the always-present system state frame; the BMS
+    // frame may be absent on the Hunter SE.
+    battery_msg.voltage = system_state.battery_voltage;
+    battery_msg.current = bms.current;
+    battery_msg.temperature = bms.temperature;
+    battery_msg.percentage = bms.battery_soc / 100.0f;  // SOC [%] -> [0,1]
+    battery_msg.charge = nan;
+    battery_msg.capacity = nan;
+    battery_msg.design_capacity = nan;
+    battery_msg.power_supply_status =
+        sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_UNKNOWN;
+    battery_msg.power_supply_health =
+        sensor_msgs::msg::BatteryState::POWER_SUPPLY_HEALTH_UNKNOWN;
+    battery_msg.power_supply_technology =
+        sensor_msgs::msg::BatteryState::POWER_SUPPLY_TECHNOLOGY_LION;
+    battery_msg.present = true;
+    
+    battery_state_pub_->publish(battery_msg);
   }
 
   void PublishOdometryToROS(const MotionStateMessage &msg, double dt) {


### PR DESCRIPTION
## Summary

hunter_base ノードから、ROS 標準の `sensor_msgs/BatteryState` 型で `/battery_state` トピックを publish するようにする。既存の `/hunter_status` はそのまま維持する。

- fix #19

## Detail

- `HunterMessenger` に `/battery_state`（`sensor_msgs/BatteryState`）の publisher を追加する。
- publish 処理を `PublishBatteryStateToROS()` 関数として切り出し、`PublishOdometryToROS()` と同様に `PublishStateToROS()` から呼び出す。
- 各フィールドのマッピング:
  - `voltage` … `system_state.battery_voltage`（常に存在するシステム状態フレーム由来）
  - `current` / `temperature` / `percentage` … `GetCommonSensorState()` の BMS basic フレーム由来（`battery_soc` は % → 0〜1 に変換）
  - `charge` / `capacity` / `design_capacity` … 取得不可のため NaN
  - `power_supply_technology` … `LION`
- `sensor_msgs` は既存の依存に含まれるため、CMakeLists.txt / package.xml の変更は不要。

## Impact

- `HunterMessenger::PublishStateToROS()` に publish 呼び出しを1行追加するのみで、既存の `/hunter_status`・`/odom` の挙動には影響しない。
- 新規トピック `/battery_state` が増える。

## Test

* [x] ビルドが通った
* [ ] gazebo環境で動作した
* [x] 実機環境で動作した

未実施（ビルド・実機確認は今後）。

## Attention

- BMS basic フレームは Hunter SE では送信されない可能性があり、その場合 `current` / `temperature` / `percentage` は 0 のままになる。実機で `ros2 topic echo /battery_state` での確認を推奨する。
- `voltage` は BMS 由来ではなく、常時取得できるシステム状態フレーム由来の値を採用。